### PR TITLE
Prevent packing without enabling `ContinuousIntegrationBuild`

### DIFF
--- a/CodeStyle/build/Polyadic.CodeStyle.targets
+++ b/CodeStyle/build/Polyadic.CodeStyle.targets
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+	<Target Name="_PolyadicCodeStylePreventLocalPack" BeforeTargets="Pack" Condition="'$(ContinuousIntegrationBuild)' != 'true' And '$(IsPackable)' == 'true'">
+		<PropertyGroup>
+			<_WorkflowUrl>$(PackageProjectUrl)/actions?query=branch%253Amain</_WorkflowUrl>
+			<_LinkPrefix>%1b]8;;</_LinkPrefix>
+			<_LinkInfix>%1b\</_LinkInfix>
+			<_LinkSuffix>$(_LinkPrefix)$(_LinkInfix)</_LinkSuffix>
+		</PropertyGroup>
+		<Error Text="Do not publish locally built packages to NuGet.org.
+Download the artifacts $(_LinkPrefix)$(_WorkflowUrl)$(_LinkInfix)published on GitHub Actions$(_LinkSuffix) instead.
+You can alternatively run `dotnet pack /p:ContinuousIntegrationBuild=true`." />
+	</Target>
+</Project>


### PR DESCRIPTION
See: https://github.com/polyadic/funcky/issues/820

This PR introduces an error message when packing a project without enabling `ContinuousIntegrationBuild`.

![image](https://github.com/user-attachments/assets/bebfa4fa-940f-4f36-8361-c7fbeb5c0617)
